### PR TITLE
Reduce boiler plate in tests

### DIFF
--- a/botbowl/core/procedure.py
+++ b/botbowl/core/procedure.py
@@ -3648,16 +3648,16 @@ class ThrowIn(Procedure):
             x = 0 if roll_direction.get_sum() == 1 else 1
         elif self.ball.position.y == 1:  # Above
             y = 1
-            x = -1 if roll_direction.get_sum() == 3 else 1
+            x = 2 - roll_direction.get_sum()
         elif self.ball.position.y == len(self.game.arena.board)-2:  # Below
             y = -1
-            x = -1 if roll_direction.get_sum() == 1 else 1
+            x = -2 + roll_direction.get_sum()
         elif self.ball.position.x == 1:  # Right
             x = 1
-            y = -1 if roll_direction.get_sum() == 3 else 1
+            y = -2 + roll_direction.get_sum()
         elif self.ball.position.x == len(self.game.arena.board[0])-2:  # Left
             x = -1
-            y = -1 if roll_direction.get_sum() == 1 else 1
+            y = 2 - roll_direction.get_sum()
 
         for i in range(roll_distance.get_sum()):
             self.ball.move(x, y)

--- a/tests/ai/test_pathfinding.py
+++ b/tests/ai/test_pathfinding.py
@@ -353,8 +353,8 @@ def test_foul_after_gfi(pf):
 
 @pytest.mark.parametrize("pf", pathfinding_modules_to_test)
 def test_foul(pf):
-    game, player, opp_player_1, opp_player_2 = get_custom_game_turn(player_positions=[(1, 1)],
-                                                      opp_player_positions=[(1, 2), (1, 3)])
+    game, (player, opp_player_1, opp_player_2) = get_custom_game_turn(player_positions=[(1, 1)],
+                                                                      opp_player_positions=[(1, 2), (1, 3)])
 
     player.role.ma = 1
     opp_player_1.state.up = False
@@ -380,8 +380,8 @@ def test_foul(pf):
 
 @pytest.mark.parametrize("pf", pathfinding_modules_to_test)
 def test_handoff(pf):
-    game, player, teammate_1, teammate_2 = get_custom_game_turn(player_positions=[(1, 1), (1, 2), (1, 3)],
-                                                                ball_position=(1, 1))
+    game, (player, teammate_1, teammate_2) = get_custom_game_turn(player_positions=[(1, 1), (1, 2), (1, 3)],
+                                                                  ball_position=(1, 1))
 
     player.role.ma = 1
     pathfinder = pf.Pathfinder(game,

--- a/tests/game/test_interception.py
+++ b/tests/game/test_interception.py
@@ -3,58 +3,34 @@ import pytest
 
 
 def test_interception_success():
-    game = get_game_turn()
-    team = game.get_agent_team(game.actor)
-    opp_team = game.get_opp_team(team)
-    game.clear_board()
-    passer = team.players[0]
-    passer.role.skills = []
-    catcher = team.players[1]
-    catcher.role.skills = []
-    interceptor = opp_team.players[0]
-    interceptor.role.skills = []
-    interceptor.role.ag = 3
-    game.put(passer, Square(1, 1))
-    game.put(interceptor, Square(5, 1))
-    game.put(catcher, Square(10, 1))
-    game.get_ball().move_to(passer.position)
-    game.get_ball().is_carried = True
-    game.state.weather = WeatherType.NICE
-    game.set_available_actions()
+    game, (passer, catcher, interceptor) = get_custom_game_turn(player_positions=[(1, 1), (10, 1)],
+                                                                opp_player_positions=[(5, 1)],
+                                                                ball_position=(1, 1))
+
     game.step(Action(ActionType.START_PASS, player=passer))
-    D6.fix(6)  # Interception
     game.step(Action(ActionType.PASS, position=catcher.position))
-    game.step(Action(ActionType.SELECT_PLAYER, player=interceptor))
+
+    # fix interception roll
+    with only_fixed_rolls(game, d6=[6]):
+        game.step(Action(ActionType.SELECT_PLAYER, player=interceptor))
+
     assert game.has_report_of_type(OutcomeType.INTERCEPTION)
     assert game.get_ball_carrier() == interceptor
 
 
 def test_interception_safe_throw_success():
-    game = get_game_turn()
-    team = game.get_agent_team(game.actor)
-    opp_team = game.get_opp_team(team)
-    game.clear_board()
-    passer = team.players[0]
-    passer.extra_skills = [Skill.SAFE_THROW]
-    catcher = team.players[1]
-    catcher.extra_skills = []
-    interceptor = opp_team.players[0]
-    interceptor.role.ag = 3
-    interceptor.extra_skills = []
-    game.put(passer, Square(1, 1))
-    game.put(interceptor, Square(5, 1))
-    game.put(catcher, Square(10, 1))
-    game.get_ball().move_to(passer.position)
-    game.get_ball().is_carried = True
-    game.state.weather = WeatherType.NICE
-    game.set_available_actions()
+    game, (passer, catcher, interceptor) = get_custom_game_turn(player_positions=[(1, 1), (10, 1)],
+                                                                opp_player_positions=[(5, 1)],
+                                                                ball_position=(1, 1))
+    passer.extra_skills.append(Skill.SAFE_THROW)
+
     game.step(Action(ActionType.START_PASS, player=passer))
-    D6.fix(6)  # Interception
-    D6.fix(4)  # Safe throw agility roll
-    D6.fix(6)  # Pass
-    D6.fix(6)  # Catch
     game.step(Action(ActionType.PASS, position=catcher.position))
-    game.step(Action(ActionType.SELECT_PLAYER, player=interceptor))
+
+    # fix interception roll, safe throw roll, pass roll, catch roll
+    with only_fixed_rolls(game, d6=[6, 4, 6, 6]):
+        game.step(Action(ActionType.SELECT_PLAYER, player=interceptor))
+
     assert game.has_report_of_type(OutcomeType.INTERCEPTION)
     assert game.has_report_of_type(OutcomeType.SKILL_USED)
     assert game.has_report_of_type(OutcomeType.SUCCESSFUL_CATCH)
@@ -62,31 +38,20 @@ def test_interception_safe_throw_success():
 
 
 def test_interception_safe_throw_fail():
-    game = get_game_turn()
-    team = game.get_agent_team(game.actor)
-    opp_team = game.get_opp_team(team)
-    game.clear_board()
-    passer = team.players[0]
-    passer.extra_skills = [Skill.SAFE_THROW]
-    catcher = team.players[1]
-    catcher.extra_skills = []
-    interceptor = opp_team.players[0]
-    interceptor.role.ag = 3
-    interceptor.extra_skills = []
-    game.put(passer, Square(1, 1))
-    game.put(interceptor, Square(5, 1))
-    game.put(catcher, Square(10, 1))
-    game.get_ball().move_to(passer.position)
-    game.get_ball().is_carried = True
-    game.state.weather = WeatherType.NICE
-    game.set_available_actions()
+    game, (passer, catcher, interceptor) = get_custom_game_turn(player_positions=[(1, 1), (10, 1)],
+                                                                opp_player_positions=[(5, 1)],
+                                                                ball_position=(1, 1),
+                                                                rerolls=1)
+    passer.extra_skills.append(Skill.SAFE_THROW)
+
     game.step(Action(ActionType.START_PASS, player=passer))
-    D6.fix(6)  # Interception
-    D6.fix(3)  # Safe throw agility roll
-    D6.fix(3)  # Safe throw agility re-roll
     game.step(Action(ActionType.PASS, position=catcher.position))
-    game.step(Action(ActionType.SELECT_PLAYER, player=interceptor))
-    game.step(Action(ActionType.USE_REROLL))
+
+    # fix interception roll, safe throw roll, safe throw reroll
+    with only_fixed_rolls(game, d6=[6, 3, 3]):
+        game.step(Action(ActionType.SELECT_PLAYER, player=interceptor))
+        game.step(Action(ActionType.USE_REROLL))
+
     assert game.has_report_of_type(OutcomeType.INTERCEPTION)
     assert game.has_report_of_type(OutcomeType.SKILL_USED)
     assert game.get_ball_carrier() == interceptor

--- a/tests/game/test_pass.py
+++ b/tests/game/test_pass.py
@@ -111,9 +111,9 @@ def test_strong_arm():
 
 
 def test_pass_nerves_of_steel():
-    game, passer, catcher, _ = get_custom_game_turn(player_positions=[(1,1), (8,1)],
-                                                    opp_player_positions=[(1,2)],
-                                                    ball_position=(1,1))
+    game, (passer, catcher, _) = get_custom_game_turn(player_positions=[(1,1), (8,1)],
+                                                      opp_player_positions=[(1,2)],
+                                                      ball_position=(1,1))
 
     # one TZ on the thrower
     assert len(game.get_adjacent_opponents(passer, down=False, stunned=False)) == 1
@@ -125,36 +125,19 @@ def test_pass_nerves_of_steel():
     # nos removes the 1 TZ impact
     assert pass_mods + 1 == nos_pass_mods
 
+
 @pytest.mark.parametrize("pass_skill", [True, False]) 
 def test_pass_roll_fumble(pass_skill): 
-    game = get_game_turn()
-    team = game.get_agent_team(game.actor)
-    game.clear_board()
-    game.state.weather = WeatherType.NICE
-    game.state.teams[0].state.rerolls = 0
-    
-    passer = team.players[0]
-    passer.role.skills = [Skill.PASS] if pass_skill else [] 
-    passer.role.ag = 3
-    game.put(passer, Square(2, 2))
-    game.get_ball().move_to(passer.position)
-    game.get_ball().is_carried = True
-    
-    catcher = team.players[1]
-    catcher_position = Square(passer.position.x + 6, passer.position.y + 0)
-    game.put(catcher, catcher_position)
-    
-    game.set_available_actions()
-    game.state.reports.clear() 
-    
+    game, (passer, catcher) = get_custom_game_turn(player_positions=[(2, 2), (8, 2)],
+                                                   ball_position=(2, 2))
+
+    passer.role.skills = [Skill.PASS] if pass_skill else []
+
     D6.fix(1)  # Fumble pass
     D6.fix(6)  # Successful pass after skill re-roll
-    
-    if pass_skill: 
-        assert passer.can_use_skill(Skill.PASS)
-    
+
     game.step(Action(ActionType.START_PASS, player=passer))
-    game.step(Action(ActionType.PASS, position=catcher_position ))
+    game.step(Action(ActionType.PASS, position=catcher.position))
     
     if pass_skill:
         assert game.has_report_of_type(OutcomeType.FUMBLE)
@@ -170,8 +153,8 @@ def test_pass_roll_fumble(pass_skill):
 
 @pytest.mark.parametrize("pass_skill", [True, False]) 
 def test_pass_roll_inaccurate(pass_skill): 
-    game, passer, catcher = get_custom_game_turn(player_positions=[(5,5), (8,5)],
-                                                 ball_position=(5,5))
+    game, (passer, catcher) = get_custom_game_turn(player_positions=[(5,5), (8,5)],
+                                                   ball_position=(5,5))
     passer.role.skills = [Skill.PASS] if pass_skill else []
 
     D6.fix(2)  # Inaccurate pass
@@ -197,14 +180,13 @@ def test_pass_roll_inaccurate(pass_skill):
 
 
 def test_pass_safe_throw():
-    game, passer, catcher = get_custom_game_turn(player_positions=[(2,2), (14,2)],
-                                                 ball_position=(2,2))
+    game, (passer, catcher) = get_custom_game_turn(player_positions=[(2,2), (14,2)],
+                                                   ball_position=(2,2))
     passer.role.skills = [Skill.SAFE_THROW]
 
-    D6.fix(2)  # Fumble pass
-
     game.step(Action(ActionType.START_PASS, player=passer))
-    game.step(Action(ActionType.PASS, position=catcher.position))
+    with only_fixed_rolls(game, d6=[2]):
+        game.step(Action(ActionType.PASS, position=catcher.position))
 
     assert game.has_report_of_type(OutcomeType.SKILL_USED)
     assert not game.has_report_of_type(OutcomeType.FUMBLE)

--- a/tests/game/test_pass.py
+++ b/tests/game/test_pass.py
@@ -111,22 +111,13 @@ def test_strong_arm():
 
 
 def test_pass_nerves_of_steel():
-    game = get_game_turn()
-    team = game.get_agent_team(game.actor)
-    game.clear_board()
-    passer = team.players[0]
-    passer.role.skills = []
-    passer.role.ag = 3
-    catcher = team.players[1]
-    game.put(passer, Square(1, 1))
-    opponent = game.get_opp_team(team).players[0]
-    game.put(opponent, Square(1, 2))
+    game, passer, catcher, _ = get_custom_game_turn(player_positions=[(1,1), (8,1)],
+                                                    opp_player_positions=[(1,2)],
+                                                    ball_position=(1,1))
+
     # one TZ on the thrower
     assert len(game.get_adjacent_opponents(passer, down=False, stunned=False)) == 1
 
-    game.state.weather = WeatherType.NICE
-    catcher_position = Square(passer.position.x + 7, passer.position.y + 0)
-    game.put(catcher, catcher_position)
     pass_distance = game.get_pass_distance(passer.position, catcher.position)
     pass_mods = game.get_pass_modifiers(passer, pass_distance)
     passer.role.skills = [Skill.NERVES_OF_STEEL]
@@ -175,29 +166,14 @@ def test_pass_roll_fumble(pass_skill):
         assert game.has_report_of_type(OutcomeType.BALL_BOUNCE_GROUND)
         assert not game.has_report_of_type(OutcomeType.ACCURATE_PASS)
         assert not game.has_report_of_type(OutcomeType.SKILL_USED)
-        
+
+
 @pytest.mark.parametrize("pass_skill", [True, False]) 
 def test_pass_roll_inaccurate(pass_skill): 
-    game = get_game_turn()
-    team = game.get_agent_team(game.actor)
-    game.clear_board()
-    game.state.weather = WeatherType.NICE
-    game.state.teams[0].state.rerolls = 0
-    
-    passer = team.players[0]
-    passer.role.skills = [Skill.PASS] if pass_skill else [] 
-    passer.role.ag = 3
-    game.put(passer, Square(5, 5))
-    game.get_ball().move_to(passer.position)
-    game.get_ball().is_carried = True
-    
-    catcher = team.players[1]
-    catcher_position = Square(passer.position.x + 3, passer.position.y + 0)
-    game.put(catcher, catcher_position)
-    
-    game.set_available_actions()
-    game.state.reports.clear() 
-    
+    game, passer, catcher = get_custom_game_turn(player_positions=[(5,5), (8,5)],
+                                                 ball_position=(5,5))
+    passer.role.skills = [Skill.PASS] if pass_skill else []
+
     D6.fix(2)  # Inaccurate pass
     D6.fix(6)  # Successful pass after skill re-roll
     
@@ -205,7 +181,7 @@ def test_pass_roll_inaccurate(pass_skill):
         assert passer.can_use_skill(Skill.PASS)
     
     game.step(Action(ActionType.START_PASS, player=passer))
-    game.step(Action(ActionType.PASS, position=catcher_position ))
+    game.step(Action(ActionType.PASS, position=catcher.position ))
     
     if pass_skill:
         assert game.has_report_of_type(OutcomeType.INACCURATE_PASS)
@@ -221,30 +197,14 @@ def test_pass_roll_inaccurate(pass_skill):
 
 
 def test_pass_safe_throw():
-    game = get_game_turn()
-    team = game.get_agent_team(game.actor)
-    game.clear_board()
-    game.state.weather = WeatherType.NICE
-    game.state.teams[0].state.rerolls = 0
-
-    passer = team.players[0]
+    game, passer, catcher = get_custom_game_turn(player_positions=[(2,2), (14,2)],
+                                                 ball_position=(2,2))
     passer.role.skills = [Skill.SAFE_THROW]
-    passer.role.ag = 3
-    game.put(passer, Square(2, 2))
-    game.get_ball().move_to(passer.position)
-    game.get_ball().is_carried = True
-
-    catcher = team.players[1]
-    catcher_position = Square(passer.position.x + 12, passer.position.y + 0)
-    game.put(catcher, catcher_position)
-
-    game.set_available_actions()
-    game.state.reports.clear()
 
     D6.fix(2)  # Fumble pass
 
     game.step(Action(ActionType.START_PASS, player=passer))
-    game.step(Action(ActionType.PASS, position=catcher_position))
+    game.step(Action(ActionType.PASS, position=catcher.position))
 
     assert game.has_report_of_type(OutcomeType.SKILL_USED)
     assert not game.has_report_of_type(OutcomeType.FUMBLE)

--- a/tests/game/test_pickup.py
+++ b/tests/game/test_pickup.py
@@ -44,8 +44,8 @@ def test_pickup_modifiers(weather):
 
 @pytest.mark.parametrize("sure_hands", [True, False])
 def test_pickup_sure_hands(sure_hands):
-    game, player = get_custom_game_turn(player_positions=[(1, 1)],
-                                        ball_position=(2, 2))
+    game, (player, ) = get_custom_game_turn(player_positions=[(1, 1)],
+                                            ball_position=(2, 2))
     if sure_hands:
         player.extra_skills.append(Skill.SURE_HANDS)
     assert player.has_skill(Skill.SURE_HANDS) == sure_hands

--- a/tests/game/test_pickup.py
+++ b/tests/game/test_pickup.py
@@ -44,24 +44,17 @@ def test_pickup_modifiers(weather):
 
 @pytest.mark.parametrize("sure_hands", [True, False])
 def test_pickup_sure_hands(sure_hands):
-    game = get_game_turn()
-    team = game.get_agent_team(game.actor)
-    game.clear_board()
-    player = team.players[0]
+    game, player = get_custom_game_turn(player_positions=[(1, 1)],
+                                        ball_position=(2, 2))
     if sure_hands:
-        player.role.skills = [Skill.SURE_HANDS]
-    else:
-        player.role.skills = []
-    player.role.ag = 3
-    game.put(player, Square(1, 1))
-    game.get_ball().move_to(Square(2, 2))
-    game.get_ball().is_carried = False
-    game.state.weather = WeatherType.NICE
-    game.set_available_actions()
+        player.extra_skills.append(Skill.SURE_HANDS)
+    assert player.has_skill(Skill.SURE_HANDS) == sure_hands
+
     game.step(Action(ActionType.START_MOVE, player=player))
-    D6.fix(1) # Failed pickup
+    D6.fix(1)  # Failed pickup
     D6.fix(6)  # Successful pickup
     game.step(Action(ActionType.MOVE, position=Square(2, 2)))
+
     if sure_hands:
         assert game.has_report_of_type(OutcomeType.FAILED_PICKUP)
         assert game.has_report_of_type(OutcomeType.SUCCESSFUL_PICKUP)

--- a/tests/game/test_throw_in.py
+++ b/tests/game/test_throw_in.py
@@ -8,9 +8,9 @@ import pytest
                                        ((5, 14), (5, 15)) ])
 def test_crowd_surf_ball_carrier(positions):
     blocker_pos, ball_carrier_pos = positions
-    game, blocker, ball_carrier = get_custom_game_turn(player_positions=[blocker_pos],
-                                                       opp_player_positions=[ball_carrier_pos],
-                                                       ball_position=ball_carrier_pos)
+    game, (blocker, ball_carrier) = get_custom_game_turn(player_positions=[blocker_pos],
+                                                         opp_player_positions=[ball_carrier_pos],
+                                                         ball_position=ball_carrier_pos)
     throw_in_from_square = ball_carrier.position
     delta_x = ball_carrier.position.x - blocker.position.x
     delta_y = ball_carrier.position.y - blocker.position.y

--- a/tests/game/test_throw_in.py
+++ b/tests/game/test_throw_in.py
@@ -1,24 +1,40 @@
 from tests.util import *
+import pytest
 
 
-def test_crowd_surf_ball_carrier():
-    game, blocker, ball_carrier = get_custom_game_turn(player_positions=[(5, 2)],
-                                                       opp_player_positions=[(5, 1)],
-                                                       ball_position=(5, 1))
+@pytest.mark.parametrize("positions", [((5, 2), (5, 1)),
+                                       ((2, 5), (1, 5)),
+                                       ((25, 5), (26, 5)),
+                                       ((5, 14), (5, 15)) ])
+def test_crowd_surf_ball_carrier(positions):
+    blocker_pos, ball_carrier_pos = positions
+    game, blocker, ball_carrier = get_custom_game_turn(player_positions=[blocker_pos],
+                                                       opp_player_positions=[ball_carrier_pos],
+                                                       ball_position=ball_carrier_pos)
+    throw_in_from_square = ball_carrier.position
+    delta_x = ball_carrier.position.x - blocker.position.x
+    delta_y = ball_carrier.position.y - blocker.position.y
 
     with only_fixed_rolls(game, block_dice=[BBDieResult.PUSH]):
         game.step(Action(ActionType.START_BLOCK, player=blocker))
         game.step(Action(ActionType.BLOCK, player=ball_carrier))
-        game.step(Action(ActionType.SELECT_PUSH, position=Square(5, 0)))
-        game.step(Action(ActionType.PUSH, position=Square(5, 0)))
+        game.step(Action(ActionType.SELECT_PUSH))
+        push_to = game.get_square(ball_carrier.position.x + delta_x, ball_carrier.position.y + delta_y)
+        game.step(Action(ActionType.PUSH, position=push_to))
 
     # Fix crowd surf injury roll, throw in distance roll, throw in direction roll, bounce direction roll
-    with only_fixed_rolls(game, d6=[2, 2, 2, 2], d3=[2], d8=[7]):
+    throw_in_distance_1 = 2
+    throw_in_distance_2 = 2
+
+    with only_fixed_rolls(game, d6=[2, 2, throw_in_distance_1, throw_in_distance_2], d3=[2], d8=[7]):
         game.step(Action(ActionType.FOLLOW_UP, position=blocker.position))
 
     # throw in is made from Square(5,1) and
     # should go in positive y-direction for 2+2+1=5 step. Ending up at Square(5,6)
-    final_square = Square(5, 6)
+    throw_in_distance = throw_in_distance_1 + throw_in_distance_2
+
+    final_square = game.get_square(throw_in_from_square.x - throw_in_distance*delta_x,
+                                   throw_in_from_square.y - throw_in_distance*delta_y + 1)
 
     assert game.has_report_of_type(OutcomeType.THROW_IN)
     assert game.get_ball().position == final_square

--- a/tests/game/test_throw_in.py
+++ b/tests/game/test_throw_in.py
@@ -1,0 +1,24 @@
+from tests.util import *
+
+
+def test_crowd_surf_ball_carrier():
+    game, blocker, ball_carrier = get_custom_game_turn(player_positions=[(5, 2)],
+                                                       opp_player_positions=[(5, 1)],
+                                                       ball_position=(5, 1))
+
+    with only_fixed_rolls(game, block_dice=[BBDieResult.PUSH]):
+        game.step(Action(ActionType.START_BLOCK, player=blocker))
+        game.step(Action(ActionType.BLOCK, player=ball_carrier))
+        game.step(Action(ActionType.SELECT_PUSH, position=Square(5, 0)))
+        game.step(Action(ActionType.PUSH, position=Square(5, 0)))
+
+    # Fix crowd surf injury roll, throw in distance roll, throw in direction roll, bounce direction roll
+    with only_fixed_rolls(game, d6=[2, 2, 2, 2], d3=[2], d8=[7]):
+        game.step(Action(ActionType.FOLLOW_UP, position=blocker.position))
+
+    # throw in is made from Square(5,1) and
+    # should go in positive y-direction for 2+2+1=5 step. Ending up at Square(5,6)
+    final_square = Square(5, 6)
+
+    assert game.has_report_of_type(OutcomeType.THROW_IN)
+    assert game.get_ball().position == final_square

--- a/tests/util.py
+++ b/tests/util.py
@@ -47,13 +47,13 @@ def get_game_turn(seed=0, empty=False):
         game_turn_full[seed] = deepcopy(game)
     return game
 
-Position = Union[Square, Tuple[int, int]]
 
+Position = Union[Square, Tuple[int, int]]
 
 
 def get_custom_game_turn(player_positions: List[Position], opp_player_positions: Optional[List[Position]] = None,
                          ball_position: Optional[Position] = None, weather: WeatherType = WeatherType.NICE,
-                         rerolls: int = 0) \
+                         rerolls: int = 0, forward_model_enabled=False, pathfinding_enabled=False) \
         -> Tuple:
     """
     :param player_positions: places human linemen of active team in these squares
@@ -61,6 +61,8 @@ def get_custom_game_turn(player_positions: List[Position], opp_player_positions:
     :param ball_position: places ball in this square.
     :param weather:
     :param rerolls: number of rerolls
+    :param forward_model_enabled:
+    :param pathfinding_enabled:
     :return: tuple with created game object followed by all the placed players
     """
     game = get_game_turn(empty=True)
@@ -75,7 +77,6 @@ def get_custom_game_turn(player_positions: List[Position], opp_player_positions:
             return obj
         else:
             return game.get_square(obj[0], obj[1])
-
 
     return_list = [game]
 
@@ -95,8 +96,12 @@ def get_custom_game_turn(player_positions: List[Position], opp_player_positions:
         game.get_ball().move_to(assert_square_type(ball_position))
         game.get_ball().is_carried = game.get_player_at(assert_square_type(ball_position)) is not None
 
+    game.config.pathfinding_enabled = pathfinding_enabled
     game.set_available_actions()
     game.state.reports.clear()
+
+    if forward_model_enabled:
+        game.enable_forward_model()
 
     return tuple(return_list)
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -272,13 +272,15 @@ def only_fixed_rolls(game: botbowl.Game,
 
     try:
         yield
-    finally:
-        game.rnd = rnd
 
         if assert_fixes_consumed:
             assert len(botbowl.D3.FixedRolls) == 0, "Not all fixed D3 rolls were consumed"
             assert len(botbowl.D6.FixedRolls) == 0, "Not all fixed D6 rolls were consumed"
             assert len(botbowl.D8.FixedRolls) == 0, "Not all fixed D8 rolls were consumed"
             assert len(botbowl.BBDie.FixedRolls) == 0, "Not all fixed BBDie rolls were consumed"
+    finally:
+        game.rnd = rnd
+
+
 
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from typing import List, Optional, Tuple, Union
 
 from botbowl.core.game import *
@@ -224,3 +225,56 @@ def get_block_players(game, team):
             defender = adjacent[0]
             break
     return attacker, defender
+
+
+@contextmanager
+def only_fixed_rolls(game: botbowl.Game,
+                     d3: Optional[List[int]] = None,
+                     d6: Optional[List[int]] = None,
+                     d8: Optional[List[int]] = None,
+                     block_dice: Optional[List[BBDieResult]] = None):
+    """
+    Context manager that ensures that
+      1) There are no fixes and the fixes rolls according to arguments
+      2) No roll other than the fixed rolls are used i.e. no randomness
+      3) All fixed rolls are consumed
+    usage:
+    > with only_fixed_rolls(game, block_dice=[BBDieResult.DEFENDER_DOWN], d6=[6, 6]):
+    >     game.step(...)
+
+    """
+    assert len(botbowl.D3.FixedRolls) == 0, f"There are fixed D3 rolls={botbowl.D3.FixedRolls}"
+    assert len(botbowl.D6.FixedRolls) == 0, f"There are fixed D6 rolls={botbowl.D6.FixedRolls}"
+    assert len(botbowl.D8.FixedRolls) == 0, f"There are fixed D8 rolls={botbowl.D8.FixedRolls}"
+    assert len(botbowl.BBDie.FixedRolls) == 0, f"There are fixed BBDie rolls={botbowl.BBDie.FixedRolls}"
+
+    if d3 is not None:
+        for roll in d3:
+            assert roll in {1, 2, 3}
+            botbowl.D3.fix(roll)
+    if d6 is not None:
+        for roll in d6:
+            assert roll in {1, 2, 3, 4, 5, 6}
+            botbowl.D6.fix(roll)
+    if d8 is not None:
+        for roll in d8:
+            assert roll in {1, 2, 3, 4, 5, 6, 7, 8}
+            botbowl.D8.fix(roll)
+    if BBDie is not None:
+        for roll in block_dice:
+            assert roll in BBDieResult
+            botbowl.BBDie.fix(roll)
+
+    rnd = game.rnd
+    game.rnd = None
+
+    try:
+        yield
+    finally:
+        game.rnd = rnd
+        assert len(botbowl.D3.FixedRolls) == 0, "Not all fixed D3 rolls where consumed"
+        assert len(botbowl.D6.FixedRolls) == 0, "Not all fixed D6 rolls where consumed"
+        assert len(botbowl.D8.FixedRolls) == 0, "Not all fixed D8 rolls where consumed"
+        assert len(botbowl.BBDie.FixedRolls) == 0, "Not all fixed BBDie rolls where consumed"
+
+

--- a/tests/util.py
+++ b/tests/util.py
@@ -229,10 +229,12 @@ def get_block_players(game, team):
 
 @contextmanager
 def only_fixed_rolls(game: botbowl.Game,
-                     d3: Optional[List[int]] = None,
-                     d6: Optional[List[int]] = None,
-                     d8: Optional[List[int]] = None,
-                     block_dice: Optional[List[BBDieResult]] = None):
+                     assert_no_prev_fixes: bool = True,
+                     assert_fixes_consumed: bool = True,
+                     d3: Optional[Iterable[int]] = None,
+                     d6: Optional[Iterable[int]] = None,
+                     d8: Optional[Iterable[int]] = None,
+                     block_dice: Optional[Iterable[BBDieResult]] = None):
     """
     Context manager that ensures that
       1) There are no fixes and the fixes rolls according to arguments
@@ -242,10 +244,11 @@ def only_fixed_rolls(game: botbowl.Game,
     > with only_fixed_rolls(game, block_dice=[BBDieResult.DEFENDER_DOWN], d6=[6, 6]):
     >     game.step(...)
     """
-    assert len(botbowl.D3.FixedRolls) == 0, f"There are fixed D3 rolls={botbowl.D3.FixedRolls}"
-    assert len(botbowl.D6.FixedRolls) == 0, f"There are fixed D6 rolls={botbowl.D6.FixedRolls}"
-    assert len(botbowl.D8.FixedRolls) == 0, f"There are fixed D8 rolls={botbowl.D8.FixedRolls}"
-    assert len(botbowl.BBDie.FixedRolls) == 0, f"There are fixed BBDie rolls={botbowl.BBDie.FixedRolls}"
+    if assert_no_prev_fixes:
+        assert len(botbowl.D3.FixedRolls) == 0, f"There are fixed D3 rolls={botbowl.D3.FixedRolls}"
+        assert len(botbowl.D6.FixedRolls) == 0, f"There are fixed D6 rolls={botbowl.D6.FixedRolls}"
+        assert len(botbowl.D8.FixedRolls) == 0, f"There are fixed D8 rolls={botbowl.D8.FixedRolls}"
+        assert len(botbowl.BBDie.FixedRolls) == 0, f"There are fixed BBDie rolls={botbowl.BBDie.FixedRolls}"
 
     if d3 is not None:
         for roll in d3:
@@ -271,9 +274,11 @@ def only_fixed_rolls(game: botbowl.Game,
         yield
     finally:
         game.rnd = rnd
-        assert len(botbowl.D3.FixedRolls) == 0, "Not all fixed D3 rolls were consumed"
-        assert len(botbowl.D6.FixedRolls) == 0, "Not all fixed D6 rolls were consumed"
-        assert len(botbowl.D8.FixedRolls) == 0, "Not all fixed D8 rolls were consumed"
-        assert len(botbowl.BBDie.FixedRolls) == 0, "Not all fixed BBDie rolls were consumed"
+
+        if assert_fixes_consumed:
+            assert len(botbowl.D3.FixedRolls) == 0, "Not all fixed D3 rolls were consumed"
+            assert len(botbowl.D6.FixedRolls) == 0, "Not all fixed D6 rolls were consumed"
+            assert len(botbowl.D8.FixedRolls) == 0, "Not all fixed D8 rolls were consumed"
+            assert len(botbowl.BBDie.FixedRolls) == 0, "Not all fixed BBDie rolls were consumed"
 
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -238,10 +238,9 @@ def only_fixed_rolls(game: botbowl.Game,
       1) There are no fixes and the fixes rolls according to arguments
       2) No roll other than the fixed rolls are used i.e. no randomness
       3) All fixed rolls are consumed
-    usage:
+    Example usage:
     > with only_fixed_rolls(game, block_dice=[BBDieResult.DEFENDER_DOWN], d6=[6, 6]):
     >     game.step(...)
-
     """
     assert len(botbowl.D3.FixedRolls) == 0, f"There are fixed D3 rolls={botbowl.D3.FixedRolls}"
     assert len(botbowl.D6.FixedRolls) == 0, f"There are fixed D6 rolls={botbowl.D6.FixedRolls}"
@@ -272,9 +271,9 @@ def only_fixed_rolls(game: botbowl.Game,
         yield
     finally:
         game.rnd = rnd
-        assert len(botbowl.D3.FixedRolls) == 0, "Not all fixed D3 rolls where consumed"
-        assert len(botbowl.D6.FixedRolls) == 0, "Not all fixed D6 rolls where consumed"
-        assert len(botbowl.D8.FixedRolls) == 0, "Not all fixed D8 rolls where consumed"
-        assert len(botbowl.BBDie.FixedRolls) == 0, "Not all fixed BBDie rolls where consumed"
+        assert len(botbowl.D3.FixedRolls) == 0, "Not all fixed D3 rolls were consumed"
+        assert len(botbowl.D6.FixedRolls) == 0, "Not all fixed D6 rolls were consumed"
+        assert len(botbowl.D8.FixedRolls) == 0, "Not all fixed D8 rolls were consumed"
+        assert len(botbowl.BBDie.FixedRolls) == 0, "Not all fixed BBDie rolls were consumed"
 
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -260,7 +260,7 @@ def only_fixed_rolls(game: botbowl.Game,
         for roll in d8:
             assert roll in {1, 2, 3, 4, 5, 6, 7, 8}
             botbowl.D8.fix(roll)
-    if BBDie is not None:
+    if block_dice is not None:
         for roll in block_dice:
             assert roll in BBDieResult
             botbowl.BBDie.fix(roll)

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,9 +1,9 @@
-from contextlib import contextmanager
-from typing import List, Optional, Tuple, Union
-
 from botbowl.core.game import *
 from botbowl.ai.bots.random_bot import *
 from copy import deepcopy
+
+from typing import List, Optional, Tuple, Union, Iterable, Any
+from contextlib import contextmanager
 
 game_turn_empty = {}
 game_turn_full = {}
@@ -55,7 +55,7 @@ Position = Union[Square, Tuple[int, int]]
 def get_custom_game_turn(player_positions: List[Position], opp_player_positions: Optional[List[Position]] = None,
                          ball_position: Optional[Position] = None, weather: WeatherType = WeatherType.NICE,
                          rerolls: int = 0, forward_model_enabled=False, pathfinding_enabled=False) \
-        -> Tuple:
+        -> Tuple[Game, Tuple[Player, ...]]:
     """
     :param player_positions: places human linemen of active team in these squares
     :param opp_player_positions: places human linemen of not active team in these squares
@@ -79,19 +79,19 @@ def get_custom_game_turn(player_positions: List[Position], opp_player_positions:
         else:
             return game.get_square(obj[0], obj[1])
 
-    return_list = [game]
+    added_players = []
 
     for i, sq in enumerate(player_positions):
         player = team_players[i]
         game.put(player, assert_square_type(sq))
-        return_list.append(player)
+        added_players.append(player)
 
     if opp_player_positions is not None:
         opp_team_players = [player for player in game.get_opp_team(team).players if player.role.name == "Lineman"]
         for i, sq in enumerate(opp_player_positions):
             player = opp_team_players[i]
             game.put(player, assert_square_type(sq))
-            return_list.append(player)
+            added_players.append(player)
 
     if ball_position is not None:
         game.get_ball().move_to(assert_square_type(ball_position))
@@ -104,7 +104,7 @@ def get_custom_game_turn(player_positions: List[Position], opp_player_positions:
     if forward_model_enabled:
         game.enable_forward_model()
 
-    return tuple(return_list)
+    return game, tuple(added_players)
 
 
 def get_game_kickoff(seed=0):


### PR DESCRIPTION
This refactor aims to reduce the amount of boiler plate code needed in the tests. The new function `get_custom_game_turn` does all the boiler plate for you. I've refactored a few tests with this new function to showcase the improvement. 

Before we had this
```python
def test_pass_safe_throw():
    game = get_game_turn()
    team = game.get_agent_team(game.actor)
    game.clear_board()
    game.state.weather = WeatherType.NICE
    game.state.teams[0].state.rerolls = 0

    passer = team.players[0]
    passer.role.skills = [Skill.SAFE_THROW]
    passer.role.ag = 3
    game.put(passer, Square(2, 2))
    game.get_ball().move_to(passer.position)
    game.get_ball().is_carried = True

    catcher = team.players[1]
    catcher_position = Square(passer.position.x + 12, passer.position.y + 0)
    game.put(catcher, catcher_position)

    game.set_available_actions()
    game.state.reports.clear()

    D6.fix(2)  # Fumble pass

    game.step(Action(ActionType.START_PASS, player=passer))
    game.step(Action(ActionType.PASS, position=catcher_position))

    assert game.has_report_of_type(OutcomeType.SKILL_USED)
    assert not game.has_report_of_type(OutcomeType.FUMBLE)
    assert game.get_ball_carrier() == passer
```

And now we have this: 
```python 
def test_pass_safe_throw():
    game, passer, catcher = get_custom_game_turn(player_positions=[(2,2), (14,2)],
                                                 ball_position=(2,2))
    passer.role.skills = [Skill.SAFE_THROW]

    D6.fix(2)  # Fumble pass

    game.step(Action(ActionType.START_PASS, player=passer))
    game.step(Action(ActionType.PASS, position=catcher.position))

    assert game.has_report_of_type(OutcomeType.SKILL_USED)
    assert not game.has_report_of_type(OutcomeType.FUMBLE)
    assert game.get_ball_carrier() == passer
```

Also includes a context manager in `tests/utils.py` that makes testing more robust. Defined as: 

```python
@contextmanager
def only_fixed_rolls(game: botbowl.Game,
                     d3: Optional[List[int]] = None,
                     d6: Optional[List[int]] = None,
                     d8: Optional[List[int]] = None,
                     block_dice: Optional[List[BBDieResult]] = None):
    """
    Context manager that ensures that
      1) There are no fixes and the fixes rolls according to arguments
      2) No roll other than the fixed rolls are used i.e. no randomness
      3) All fixed rolls are consumed
    """
```
Example usage:
```python
with only_fixed_rolls(game, block_dice=[BBDieResult.DEFENDER_DOWN], d6=[6, 6]):
     game.step(...)
```