### PR TITLE
[WiP] Fixes take root stand up bug

### DIFF
--- a/botbowl/core/pathfinding/python_pathfinding.py
+++ b/botbowl/core/pathfinding/python_pathfinding.py
@@ -188,8 +188,8 @@ class Pathfinder:
         self.can_block = can_block
         self.can_handoff = can_handoff
         self.can_foul = can_foul
-        self.ma = player.get_ma() - player.state.moves
-        self.gfis = 3 if player.has_skill(Skill.SPRINT) else 2
+        self.ma = player.num_moves_left()
+        self.gfis = player.num_gfis_left()
         self.locked_nodes = np.full((game.arena.height, game.arena.width), None)
         self.nodes = np.full((game.arena.height, game.arena.width), None)
         self.tzones = np.zeros((game.arena.height, game.arena.width), dtype=np.uint8)
@@ -209,17 +209,18 @@ class Pathfinder:
         return None
 
     def get_paths(self, target=None):
-
-        ma = self.player.get_ma() - self.player.state.moves
-        self.ma = max(0, ma)
-        gfis_used = 0 if ma >= 0 else -ma
-        self.gfis = 3-gfis_used if self.player.has_skill(Skill.SPRINT) else 2-gfis_used
-
+        self.gfis = self.player.num_gfis_left()
+        self.ma = self.player.num_moves_left()
         can_dodge = self.player.has_skill(Skill.DODGE) and Skill.DODGE not in self.player.state.used_skills
         can_sure_feet = self.player.has_skill(Skill.SURE_FEET) and Skill.SURE_FEET not in self.player.state.used_skills
         can_sure_hands = self.player.has_skill(Skill.SURE_HANDS)
-        rr_states = {(self.trr, can_dodge, can_sure_feet, can_sure_hands): 1}
-        node = Node(None, self.player.position, self.ma, self.gfis, euclidean_distance=0, rr_states=rr_states,
+        rr_states = {(self.trr, can_dodge, can_sure_feet, can_sure_hands): 1}  # RRs left and probability of success
+        node = Node(None,
+                    position=self.player.position,
+                    moves_left=self.ma,
+                    gfis_left=self.gfis,
+                    euclidean_distance=0,
+                    rr_states=rr_states,
                     can_foul=self.can_foul,
                     can_handoff=self.can_handoff,
                     can_block=self.can_block)
@@ -296,7 +297,7 @@ class Pathfinder:
             return
 
         out_of_moves = False
-        if node.moves_left + node.gfis_left == 0:
+        if node.moves_left + node.gfis_left <= 0:
             if not node.can_handoff and not node.can_foul:
                 return
             out_of_moves = True

--- a/botbowl/core/procedure.py
+++ b/botbowl/core/procedure.py
@@ -2588,12 +2588,13 @@ class MoveAction(Procedure):
         self.paths = {}
         self.steps = None
         self.orig_action_type = None
-        self.can_undo = self.game.get_team_agent(player.team).human
+        self.can_undo = False
 
     def start(self):
         if self.player_action_type == PlayerActionType.MOVE:
             self.game.report(Outcome(OutcomeType.MOVE_ACTION_STARTED, player=self.player))
             self.game.state.player_action_type = PlayerActionType.MOVE
+        self.can_undo = self.game.get_team_agent(self.player.team).human and not self.player.state.failed_nega_trait_this_turn
 
     def step(self, action):
 
@@ -2715,8 +2716,6 @@ class MoveAction(Procedure):
     def available_actions(self):
         if self.steps is not None and len(self.steps) > 0:
             return []  # No actions -> Continue path
-        if self.player.state.taken_root:
-            return [ActionChoice(ActionType.END_PLAYER_TURN, team=self.player.team)]
         actions = []
         if self.game.is_quick_snap() or not self.game.config.pathfinding_enabled:
             actions = self.game.get_adjacent_move_actions(self.player)
@@ -2877,10 +2876,12 @@ class ThrowBombAction(Procedure):
         super().__init__(game)
         self.player = player
         self.game.put_bomb(Bomb(self.player.position))
+        self.can_undo = False
 
     def start(self):
         self.game.report(Outcome(OutcomeType.THROW_BOMB_ACTION_STARTED, player=self.player))
         self.game.state.player_action_type = PlayerActionType.THROW_BOMB
+        self.can_undo = self.game.get_team_agent(self.player.team).human
 
     def step(self, action):
         if action.action_type == ActionType.THROW_BOMB:
@@ -2954,11 +2955,12 @@ class BlockAction(Procedure):
     def __init__(self, game, player):
         super().__init__(game)
         self.player = player
-        self.can_undo = True
+        self.can_undo = False
 
     def start(self):
         self.game.report(Outcome(OutcomeType.BLOCK_ACTION_STARTED, player=self.player))
         self.game.state.player_action_type = PlayerActionType.BLOCK
+        self.can_undo = self.game.get_team_agent(self.player.team).human
 
     def step(self, action):
 
@@ -3973,6 +3975,7 @@ class Negatrait(Procedure, metaclass=ABCMeta):
 
     def trigger_failure(self):
         self.apply_fail_state()
+        self.player.state.failed_nega_trait_this_turn = True
         if self.ends_turn:
             self.end_turn()
 

--- a/tests/ai/test_pathfinding.py
+++ b/tests/ai/test_pathfinding.py
@@ -52,7 +52,7 @@ def test_gfi(pf):
         moves = player.get_ma() + gfis
         target = Square(position.x + moves, position.y)
         path = pf.get_safest_path(game, player, target)
-        assert len(path.steps) == moves and path.get_last_step()  == target
+        assert len(path.steps) == moves and path.get_last_step() == target
         assert path.prob == (5 / 6) ** gfis
 
 
@@ -212,7 +212,22 @@ def test_all_paths(pf):
     game.put(player, position)
     paths = pf.get_all_paths(game, player)
     assert paths is not None
-    assert len(paths) == ((player.num_moves_left() + 1) * (player.num_moves_left() + 1)) - 1
+    moves_left = player.num_moves_left(include_gfi=True)
+    assert len(paths) == ((moves_left + 1) * (moves_left + 1)) - 1
+
+
+@pytest.mark.parametrize("pf", pathfinding_modules_to_test)
+def test_all_paths_down(pf):
+    game = get_game_turn(empty=True)
+    player = game.get_reserves(game.state.away_team)[0]
+    player.role.ma = 6
+    player.state.up = False
+    position = Square(1, 1)
+    game.put(player, position)
+    paths = pf.get_all_paths(game, player)
+    assert paths is not None
+    moves_left = player.num_moves_left(include_gfi=True)
+    assert len(paths) == ((moves_left - 3 + 1) * (moves_left - 3 + 1)) - 1
 
 
 def test_that_unittest_mock_patch_works():

--- a/tests/game/test_negatraits.py
+++ b/tests/game/test_negatraits.py
@@ -88,7 +88,37 @@ def test_take_root_ends_move_turn():
 
     game.step(Action(ActionType.START_MOVE, player=player))
 
-    # check the player turn has not ended
+    # check the player turn has ended
+    assert game.state.active_player is not player
+
+
+def test_taken_root_players_can_stand_up():
+    game = get_game_turn()
+    game.config.pathfinding_enabled = True
+    team = game.get_agent_team(game.actor)
+    team.state.rerolls = 0  # ensure no reroll prompt
+
+    players = game.get_players_on_pitch(team)
+    player = players[1]
+    player.extra_skills = [Skill.TAKE_ROOT]
+    player.state.up = False
+
+    D6.FixedRolls.clear()
+    D6.fix(1)  # fail take root
+
+    game.step(Action(ActionType.START_MOVE, player=player))
+
+    # It's still that players turn
+    assert game.state.active_player is player
+
+    D6.fix(4)  # succeed stand up roll
+
+    game.step(Action(ActionType.STAND_UP, player=player))
+
+    assert player.state.up
+    assert player.state.taken_root
+
+    # Nothing more to do
     assert game.state.active_player is not player
 
 


### PR DESCRIPTION
Fixes #187 by allowing take root players to stand up.

This required some small changes to the pathfinding code but my python changes are not reflected in the cython pathfinder when I build. Can you please help @mrbermell ?

The two tests that are failing are:
- tests.ai.test_pathfinding.test_compare_cython_python_paths
- tests.framework.test_forward_model.test_deepcopy_of_game_is_correct