### PR TITLE
Pathfinding fixes - bugs #208, #211

### DIFF
--- a/botbowl/core/pathfinding/cython_pathfinding.pyx
+++ b/botbowl/core/pathfinding/cython_pathfinding.pyx
@@ -283,6 +283,9 @@ cdef class Pathfinder:
         if self.carries_ball and node.get().position.x == self.endzone_x:
             return
 
+        if (not self.carries_ball) and node.get().position == self.ball_pos:
+            return
+
         if out_of_moves and (not node.get().can_handoff) and (not node.get().can_foul):
             return
 

--- a/botbowl/core/pathfinding/cython_pathfinding.pyx
+++ b/botbowl/core/pathfinding/cython_pathfinding.pyx
@@ -130,6 +130,13 @@ cdef class Path:
                 self.handoff_roll == other.handoff_roll and \
                 self.foul_roll == other.foul_roll
 
+    def __repr__(self):
+        block = f", block_dice={self.block_dice}" if self.block_dice is not None else ""
+        handoff = f", handoff_roll={self.handoff_roll}" if self.handoff_roll is not None else ""
+        foul = f", foul_roll={self.foul_roll}" if self.foul_roll is not None else ""
+        return f"Path(target={self.steps[-1]}, prob={self.prob}, {block}{handoff}{foul})"
+
+
 # Make the forward model treat Path as an immutable type.
 forward_model.immutable_types.add(Path)
 

--- a/botbowl/core/pathfinding/cython_pathfinding.pyx
+++ b/botbowl/core/pathfinding/cython_pathfinding.pyx
@@ -167,9 +167,9 @@ cdef class Pathfinder:
         self.pitch_width = self.game.arena.width - 1
         self.pitch_height = game.arena.height -1
         self.start_pos = from_botbowl_Square( player.position )
-        ball = self.game.get_ball_position()
-        if ball is not None:
-            self.ball_pos = from_botbowl_Square(ball)
+        ball = self.game.get_ball()
+        if ball is not None and ball.on_ground:
+            self.ball_pos = from_botbowl_Square(ball.position)
         else:
             self.ball_pos = Square(-1, -1)
 

--- a/botbowl/core/pathfinding/python_pathfinding.py
+++ b/botbowl/core/pathfinding/python_pathfinding.py
@@ -193,6 +193,8 @@ class Pathfinder:
         self.can_block = can_block
         self.can_handoff = can_handoff
         self.can_foul = can_foul
+        self.carries_ball = None
+        self.endzone_x = None
         self.ma = player.num_moves_left()
         self.gfis = player.num_gfis_left()
         self.locked_nodes = np.full((game.arena.height, game.arena.width), None)
@@ -216,6 +218,9 @@ class Pathfinder:
     def get_paths(self, target=None):
         self.gfis = self.player.num_gfis_left()
         self.ma = self.player.num_moves_left()
+        self.carries_ball = self.player is self.game.get_ball_carrier()
+        self.endzone_x = 1 if self.player.team is self.game.state.home_team else self.game.arena.width - 2
+
         can_dodge = self.player.has_skill(Skill.DODGE) and Skill.DODGE not in self.player.state.used_skills
         can_sure_feet = self.player.has_skill(Skill.SURE_FEET) and Skill.SURE_FEET not in self.player.state.used_skills
         can_sure_hands = self.player.has_skill(Skill.SURE_HANDS)
@@ -299,6 +304,9 @@ class Pathfinder:
                 return
 
         if node.block_dice is not None or node.handoff_roll is not None:
+            return
+
+        if self.carries_ball and node.position.x == self.endzone_x:
             return
 
         out_of_moves = False

--- a/botbowl/core/pathfinding/python_pathfinding.py
+++ b/botbowl/core/pathfinding/python_pathfinding.py
@@ -69,6 +69,12 @@ class Path:
                self.handoff_roll == other.handoff_roll and \
                self.foul_roll == other.foul_roll
 
+    def __repr__(self):
+        block = f", block_dice={self.block_dice}" if self.block_dice is not None else ""
+        handoff = f", handoff_roll={self.handoff_roll}" if self.handoff_roll is not None else ""
+        foul = f", foul_roll={self.foul_roll}" if self.foul_roll is not None else ""
+        return f"Path(target={self.steps[-1]}, prob={self.prob}, {block}{handoff}{foul})"
+
 
 class Node:
 

--- a/botbowl/core/pathfinding/python_pathfinding.py
+++ b/botbowl/core/pathfinding/python_pathfinding.py
@@ -201,6 +201,7 @@ class Pathfinder:
         self.can_foul = can_foul
         self.carries_ball = None
         self.endzone_x = None
+        self.ball_position = None
         self.ma = player.num_moves_left()
         self.gfis = player.num_gfis_left()
         self.locked_nodes = np.full((game.arena.height, game.arena.width), None)
@@ -225,6 +226,7 @@ class Pathfinder:
         self.gfis = self.player.num_gfis_left()
         self.ma = self.player.num_moves_left()
         self.carries_ball = self.player is self.game.get_ball_carrier()
+        self.ball_position = self.game.get_ball_position() if self.game.get_ball().on_ground else None
         self.endzone_x = 1 if self.player.team is self.game.state.home_team else self.game.arena.width - 2
 
         can_dodge = self.player.has_skill(Skill.DODGE) and Skill.DODGE not in self.player.state.used_skills
@@ -315,7 +317,7 @@ class Pathfinder:
         if self.carries_ball and node.position.x == self.endzone_x:
             return
 
-        if (not self.carries_ball) and node.position == self.game.get_ball_position():
+        if (not self.carries_ball) and node.position == self.ball_position:
             return
 
         out_of_moves = False
@@ -372,7 +374,7 @@ class Pathfinder:
         if self.tzones[node.position.y][node.position.x] > 0:
             target = self._get_dodge_target(node.position, to_pos)
             next_node.apply_dodge(target)
-        if self.game.get_ball_position() == to_pos:
+        if self.ball_position == to_pos:
             target = self._get_pickup_target(to_pos)
             next_node.apply_pickup(target)
         if best_before is not None and self._dominant(next_node, best_before) == best_before:

--- a/botbowl/core/pathfinding/python_pathfinding.py
+++ b/botbowl/core/pathfinding/python_pathfinding.py
@@ -309,6 +309,9 @@ class Pathfinder:
         if self.carries_ball and node.position.x == self.endzone_x:
             return
 
+        if (not self.carries_ball) and node.position == self.game.get_ball_position():
+            return
+
         out_of_moves = False
         if node.moves_left + node.gfis_left <= 0:
             if not node.can_handoff and not node.can_foul:

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ install_requires_packages = [
           'requests',
           'Cython >= 3.0a7',
           'pytest',
-          'matplotlib'
+          'matplotlib',
+          'more_itertools'
 ]
 
 kwargs = {

--- a/tests/ai/test_pathfinding.py
+++ b/tests/ai/test_pathfinding.py
@@ -331,8 +331,8 @@ def test_all_blitz_paths_two(pf):
 
 @pytest.mark.parametrize("pf", pathfinding_modules_to_test)
 def test_handoff_after_gfi(pf):
-    game, (player, other_player) = get_custom_game_turn(player_positions=[(1, 1), (2, 2)],
-                                                        ball_position=(1, 1))
+    game, (player, other_player) = get_custom_game_turn(player_positions=[(2, 2), (3, 3)],
+                                                        ball_position=(2, 2))
     player.role.ma = 6
     player.state.moves = 8
 
@@ -391,8 +391,8 @@ def test_foul(pf):
 
 @pytest.mark.parametrize("pf", pathfinding_modules_to_test)
 def test_handoff(pf):
-    game, (player, teammate_1, teammate_2) = get_custom_game_turn(player_positions=[(1, 1), (1, 2), (1, 3)],
-                                                                  ball_position=(1, 1))
+    game, (player, teammate_1, teammate_2) = get_custom_game_turn(player_positions=[(2, 2), (2, 3), (2, 4)],
+                                                                  ball_position=(2, 2))
 
     player.role.ma = 1
     pathfinder = pf.Pathfinder(game,
@@ -485,3 +485,38 @@ def test_blitz_one_move_left(pf_enabled):
 
     assert not game.has_report_of_type(botbowl.OutcomeType.FAILED_GFI)
     assert not game.has_report_of_type(botbowl.OutcomeType.SUCCESSFUL_GFI)
+
+
+@pytest.mark.parametrize("pf", pathfinding_modules_to_test)
+@pytest.mark.parametrize("as_home", [True, False])
+def test_scoring_paths(pf, as_home):
+    home_positions = [(2, 1),
+                      (2, 2),
+                      (3, 1),
+                      (3, 2)]
+
+    away_positions = [(25, 1),
+                      (25, 2),
+                      (24, 1),
+                      (24, 2)]
+
+    ball_pos = home_positions[0] if as_home else away_positions[0]
+    end_zone_x = 1 if as_home else 26
+
+    game, _ = get_custom_game_turn(player_positions=home_positions,
+                                   opp_player_positions=away_positions,
+                                   ball_position=ball_pos)
+
+    ball_carrier = game.get_ball_carrier()
+
+    paths = pf.get_all_paths(game, ball_carrier)
+
+    assert len(paths) == 2
+
+    for path in paths:
+        # we make sure that there are no steps after passing home_td zone
+        found_td = False
+        for step in path.steps:
+            assert not found_td
+            if step.x == end_zone_x:
+                found_td = True

--- a/tests/ai/test_pathfinding.py
+++ b/tests/ai/test_pathfinding.py
@@ -1,3 +1,4 @@
+from more_itertools import first
 from tests.util import Square, get_game_turn, Skill, Action, ActionType, get_custom_game_turn
 import pytest
 import unittest.mock
@@ -466,9 +467,10 @@ def test_straight_paths(pf):
 
     for path in paths:
         if path.get_last_step().x == 7:
-            assert all(step.x==7 for step in path.steps)
+            assert all(step.x == 7 for step in path.steps)
         if path.get_last_step().y == 7:
             assert all(step.y == 7 for step in path.steps)
+
 
 @pytest.mark.parametrize("pf_enabled", [False, True])
 def test_blitz_one_move_left(pf_enabled):
@@ -530,3 +532,17 @@ def test_forced_pickup_path(pf):
     paths = pf.get_all_paths(game, player1)
     assert len(paths) == 1
     assert paths[0].get_last_step() == game.get_ball_position()
+
+
+@pytest.mark.parametrize("pf", pathfinding_modules_to_test)
+def test_forced_pickup_path(pf):
+    game, (player,) = get_custom_game_turn(player_positions=[(1, 1)],
+                                           ball_position=(3, 3),
+                                           pathfinding_enabled=True)
+    ball = game.get_ball()
+    ball.on_ground = False
+
+    paths = pf.get_all_paths(game, player)
+    path: python_pathfinding.Path = first(filter(lambda p: p.get_last_step() == ball.position, paths))
+
+    assert path.prob == 1

--- a/tests/ai/test_pathfinding.py
+++ b/tests/ai/test_pathfinding.py
@@ -520,3 +520,13 @@ def test_scoring_paths(pf, as_home):
             assert not found_td
             if step.x == end_zone_x:
                 found_td = True
+
+
+@pytest.mark.parametrize("pf", pathfinding_modules_to_test)
+def test_forced_pickup_path(pf):
+    game, (player1, player2, player3) = get_custom_game_turn(player_positions=[(1, 1), (1, 2), (2, 2)],
+                                                             ball_position=(2, 1),
+                                                             pathfinding_enabled=True)
+    paths = pf.get_all_paths(game, player1)
+    assert len(paths) == 1
+    assert paths[0].get_last_step() == game.get_ball_position()

--- a/tests/util.py
+++ b/tests/util.py
@@ -9,21 +9,23 @@ game_turn_empty = {}
 game_turn_full = {}
 
 
-def get_game_turn(seed=0, empty=False):
+def get_game_turn(seed=0, empty=False, home_team: str = 'human', away_team: str = 'orc'):
     D3.FixedRolls = []
     D6.FixedRolls = []
     D8.FixedRolls = []
     BBDie.FixedRolls = []
+
+    key = f"{seed} {home_team} {away_team}"
     if empty:
-        if seed in game_turn_empty:
-            return deepcopy(game_turn_empty[seed])
+        if key in game_turn_empty:
+            return deepcopy(game_turn_empty[key])
     else:
-        if seed in game_turn_full:
-            return deepcopy(game_turn_full[seed])
+        if key in game_turn_full:
+            return deepcopy(game_turn_full[key])
     config = load_config("gym-11")
     ruleset = load_rule_set(config.ruleset)
-    home = load_team_by_filename("human", ruleset)
-    away = load_team_by_filename("orc", ruleset)
+    home = load_team_by_filename(home_team, ruleset)
+    away = load_team_by_filename(away_team, ruleset)
     home_agent = Agent("human1", human=True)
     away_agent = Agent("human2", human=True)
     game = Game(1, home, away, home_agent, away_agent, config)
@@ -43,9 +45,9 @@ def get_game_turn(seed=0, empty=False):
     if empty:
         game.clear_board()
     if empty:
-        game_turn_empty[seed] = deepcopy(game)
+        game_turn_empty[key] = deepcopy(game)
     else:
-        game_turn_full[seed] = deepcopy(game)
+        game_turn_full[key] = deepcopy(game)
     return game
 
 
@@ -66,7 +68,7 @@ def get_custom_game_turn(player_positions: List[Position], opp_player_positions:
     :param pathfinding_enabled:
     :return: tuple with created game object followed by all the placed players
     """
-    game = get_game_turn(empty=True)
+    game = get_game_turn(empty=True, home_team='human', away_team='human')
     team = game.get_agent_team(game.actor)
     team_players = [player for player in team.players if player.role.name == "Lineman"]
 


### PR DESCRIPTION
solve #208:

> The pathfinding algorithm doesn't check for touchdown and keeps expanding. This leads to MOVE-actions that have paths that will never be completed.

and solve #211 

> During a MoveAction, I think you should only pickup the ball if you select the square with the ball in. i.e. the pathfinding should stop expanding its search if it picks up the ball. It currently doesn't. 