### PR TITLE
Bugfix pathfinding

### DIFF
--- a/botbowl/core/pathfinding/cython_pathfinding.pyx
+++ b/botbowl/core/pathfinding/cython_pathfinding.pyx
@@ -66,7 +66,7 @@ cdef class Path:
         public double prob
         public object block_dice, handoff_roll, foul_roll
 
-    def __cinit__(NodePtr n):
+    def __cinit__(self, NodePtr n):
         self.final_node = n
         self.prob = n.get().prob
         self.block_dice = None if n.get().block_dice == 0 else n.get().block_dice

--- a/botbowl/core/pathfinding/cython_pathfinding.pyx
+++ b/botbowl/core/pathfinding/cython_pathfinding.pyx
@@ -14,15 +14,12 @@ import botbowl.core.table as table
 import botbowl.core.model as model
 import botbowl.core.forward_model as forward_model
 from .python_pathfinding import _alter_state, _reset_state
-import copy
 
 from libcpp.map cimport map as mapcpp
 from libcpp.vector cimport vector
 from libcpp.queue cimport priority_queue
 from libcpp.memory cimport shared_ptr, make_shared
 
-import cython
-cimport cython
 from cython.operator import dereference
 
 from .pathing_node cimport Node, Square
@@ -30,7 +27,7 @@ ctypedef shared_ptr[Node] NodePtr
 
 
 cdef object to_botbowl_Square(Square sq):
-    return model.Square(sq.x, sq.y, )
+    return model.Square(sq.x, sq.y)
 
 cdef Square from_botbowl_Square(object sq):
     return Square(sq.x, sq.y)

--- a/botbowl/core/pathfinding/cython_pathfinding.pyx
+++ b/botbowl/core/pathfinding/cython_pathfinding.pyx
@@ -30,7 +30,7 @@ ctypedef shared_ptr[Node] NodePtr
 
 
 cdef object to_botbowl_Square(Square sq):
-    return model.Square(sq.x, sq.y)
+    return model.Square(sq.x, sq.y, )
 
 cdef Square from_botbowl_Square(object sq):
     return Square(sq.x, sq.y)
@@ -65,6 +65,13 @@ cdef class Path:
         public object _steps, _rolls
         public double prob
         public object block_dice, handoff_roll, foul_roll
+
+    def __cinit__(NodePtr n):
+        self.final_node = n
+        self.prob = n.get().prob
+        self.block_dice = None if n.get().block_dice == 0 else n.get().block_dice
+        self.handoff_roll = None if n.get().handoff_roll == 0 else n.get().handoff_roll
+        self.foul_roll = None if n.get().foul_roll == 0 else n.get().foul_roll
 
     cdef void set_node(self, NodePtr n):
         self.final_node = n
@@ -395,7 +402,7 @@ cdef class Pathfinder:
         best_before = self.locked_nodes[to_pos.y][to_pos.x]
         assists_from, assists_to = self.game.num_assists_at(self.player, player_at, to_botbowl_Square(node.get().position), foul=True)
         target = min(12, max(2, player_at.get_av() + 1 - assists_from + assists_to))
-        next_node = make_shared[Node](node, to_pos, 0, 0, node.get().euclidean_distance) )
+        next_node = make_shared[Node](node, to_pos, 0, 0, node.get().euclidean_distance)
         next_node.get().apply_foul(target)
 
         if best_node.use_count()>0 and self._best(next_node, best_node) == best_node:

--- a/botbowl/core/pathfinding/pathing_node.cpp
+++ b/botbowl/core/pathfinding/pathing_node.cpp
@@ -82,9 +82,9 @@ namespace node_ns {
         new_states[fail_state] += fail_state_p; // if fail_state not in new states, it is init as 0
     }
 
-    void Node::apply_gfi(){
-        rolls.push_back(2);
-        _apply_roll(5.0/6.0, SURE_FEET, TRR);
+    void Node::apply_gfi(int target){
+        rolls.push_back(target);
+        _apply_roll((7.0-target)/6.0, SURE_FEET, TRR);
     }
     void Node::apply_dodge(int target){
         rolls.push_back(target);

--- a/botbowl/core/pathfinding/pathing_node.h
+++ b/botbowl/core/pathfinding/pathing_node.h
@@ -58,7 +58,7 @@ namespace node_ns {
 
             void _apply_roll(double p, int skill_rr, int team_rr);
             void _add_fail_state(rr_state & new_states, rr_used & prev_state, double prev_state_p, double p, int index);
-            void apply_gfi();
+            void apply_gfi(int target);
             void apply_dodge(int target);
             void apply_pickup(int target);
             void apply_handoff(int target);

--- a/botbowl/core/pathfinding/pathing_node.pxd
+++ b/botbowl/core/pathfinding/pathing_node.pxd
@@ -31,7 +31,7 @@ cdef extern from "pathing_node.h" namespace "node_ns":
         Node(shared_ptr[Node], Square, int, int, double, int) except +   # non-root node with block dice
         Node(shared_ptr[Node], Square, int, int, double) except +        # non-root node without block dice
 
-        void apply_gfi()
+        void apply_gfi(int)
         void apply_dodge(int)
         void apply_pickup(int)
         void apply_handoff(int)

--- a/botbowl/core/procedure.py
+++ b/botbowl/core/procedure.py
@@ -2655,7 +2655,7 @@ class MoveAction(Procedure):
 
             # Start new path?
             if self.steps is None:
-                self.steps = self.paths[action.position].steps
+                self.steps = list(self.paths[action.position].steps)
                 self.orig_action_type = action.action_type
                 return False
 

--- a/tests/ai/test_pathfinding.py
+++ b/tests/ai/test_pathfinding.py
@@ -560,13 +560,12 @@ def test_snow_for_it(pf):
 
     assert len(paths) == 15
     path1 = first(filter(lambda p: p.get_last_step() == Square(3, 3), paths))
-    assert path1.rolls == [[], [3]]
+    assert path1.rolls == ([], [3])
     assert path1.prob == approx(4/6)  # prob of 3+
 
-
-    path2 = first(filter(lambda p: p.get_last_step() == Square(3, 3), paths))
-    assert path2.rolls == [[], [3], [3]]
-    assert path1.prob == approx((4 / 6)**2)  # prob of 3+ 3+
+    path2 = first(filter(lambda p: p.get_last_step() == Square(4, 4), paths))
+    assert path2.rolls == ([], [3], [3])
+    assert path2.prob == approx((4 / 6)**2)  # prob of 3+ 3+
 
 
 @pytest.mark.parametrize("pf", pathfinding_modules_to_test)
@@ -577,7 +576,7 @@ def test_pouring_rain_pickup(pf):
 
     paths = pf.get_all_paths(game, player)
     path = first(filter(lambda p: p.get_last_step() == Square(3, 3), paths))
-    assert path.rolls == [[], [4]]
+    assert path.rolls == ([], [4])
     assert path.prob == approx(0.5)  # corresponding to 4+
 
 
@@ -590,5 +589,5 @@ def test_pouring_rain_handoff(pf):
     paths = pf.Pathfinder(game, player, can_handoff=True).get_paths()
     assert len(paths) > 0
     path = first(filter(lambda p: p.get_last_step() == catcher.position, paths))
-    assert path.rolls == [[], []]
+    assert path.rolls == ([], [])
     assert path.handoff_roll == 4

--- a/tests/ai/test_pathfinding.py
+++ b/tests/ai/test_pathfinding.py
@@ -1,4 +1,6 @@
 from more_itertools import first
+from pytest import approx
+
 from tests.util import Square, get_game_turn, Skill, Action, ActionType, get_custom_game_turn
 import pytest
 import unittest.mock
@@ -546,3 +548,47 @@ def test_forced_pickup_path(pf):
     path: python_pathfinding.Path = first(filter(lambda p: p.get_last_step() == ball.position, paths))
 
     assert path.prob == 1
+
+
+@pytest.mark.parametrize("pf", pathfinding_modules_to_test)
+def test_snow_for_it(pf):
+    game, (player, ) = get_custom_game_turn(player_positions=[(1, 1)],
+                                            weather=botbowl.WeatherType.BLIZZARD)
+
+    player.role.ma = 1
+    paths = pf.get_all_paths(game, player)
+
+    assert len(paths) == 15
+    path1 = first(filter(lambda p: p.get_last_step() == Square(3, 3), paths))
+    assert path1.rolls == [[], [3]]
+    assert path1.prob == approx(4/6)  # prob of 3+
+
+
+    path2 = first(filter(lambda p: p.get_last_step() == Square(3, 3), paths))
+    assert path2.rolls == [[], [3], [3]]
+    assert path1.prob == approx((4 / 6)**2)  # prob of 3+ 3+
+
+
+@pytest.mark.parametrize("pf", pathfinding_modules_to_test)
+def test_pouring_rain_pickup(pf):
+    game, (player, ) = get_custom_game_turn(player_positions=[(1, 1)],
+                                            ball_position=(3, 3),
+                                            weather=botbowl.WeatherType.POURING_RAIN)
+
+    paths = pf.get_all_paths(game, player)
+    path = first(filter(lambda p: p.get_last_step() == Square(3, 3), paths))
+    assert path.rolls == [[], [4]]
+    assert path.prob == approx(0.5)  # corresponding to 4+
+
+
+@pytest.mark.parametrize("pf", pathfinding_modules_to_test)
+def test_pouring_rain_handoff(pf):
+    game, (player, catcher) = get_custom_game_turn(player_positions=[(2, 2), (4, 4)],
+                                                   ball_position=(2, 2),
+                                                   weather=botbowl.WeatherType.POURING_RAIN)
+
+    paths = pf.Pathfinder(game, player, can_handoff=True).get_paths()
+    assert len(paths) > 0
+    path = first(filter(lambda p: p.get_last_step() == catcher.position, paths))
+    assert path.rolls == [[], []]
+    assert path.handoff_roll == 4


### PR DESCRIPTION
I've found some typos in the cython pathfinding. Since I'm poking around in the pathfinding I will also: 

- [x] Write tests that fail without this fix, and more pf tests in general
- [x] Refactor cython to use `make_shared<Node>(...)` instead of  `NodePtr(new Node(...))`
- [x] Implement "Snow for it" in cython and python pathfinding (GFI should be 3+ instead of 2+ if weather is blizzard)
- [x] MoveAction-procedure not modify the path object, should only modify a copy of `path.steps`. Consider making `path.steps` a tuple which is an immutable container. 