### PR TITLE
Failing tests + minor python pathfinder fix

### DIFF
--- a/botbowl/core/pathfinding/python_pathfinding.py
+++ b/botbowl/core/pathfinding/python_pathfinding.py
@@ -228,8 +228,17 @@ class Pathfinder:
     def get_path(self, target):
         paths = self.get_paths(target)
         if len(paths) > 0:
-            return paths[0]
+            return self._get_shortest(paths)
         return None
+
+    def _get_shortest(self, paths):
+        d = None
+        p = None
+        for path in paths:
+            if d is None or len(path.steps) < d:
+                d = len(path.steps)
+                p = path
+        return p
 
     def get_paths(self, target=None):
         self.gfis = self.player.num_gfis_left()

--- a/tests/ai/test_pathfinding.py
+++ b/tests/ai/test_pathfinding.py
@@ -208,6 +208,45 @@ def test_path_to_endzone_away(pf):
 
 
 @pytest.mark.parametrize("pf", pathfinding_modules_to_test)
+def test_path_to_endzone_away_top(pf):
+    game = get_game_turn(empty=True)
+    player = game.get_reserves(game.state.away_team)[0]
+    player.role.ma = 6
+    position = Square(23, 1)
+    game.put(player, position)
+    path = pf.get_safest_path_to_endzone(game, player)
+    assert path is not None
+    assert len(path) == 3
+    assert path.steps[-1].x == 26
+
+
+@pytest.mark.parametrize("pf", pathfinding_modules_to_test)
+def test_path_to_endzone_away_bottom(pf):
+    game = get_game_turn(empty=True)
+    player = game.get_reserves(game.state.away_team)[0]
+    player.role.ma = 6
+    position = Square(23, 15)
+    game.put(player, position)
+    path = pf.get_safest_path_to_endzone(game, player)
+    assert path is not None
+    assert len(path) == 3
+    assert path.steps[-1].x == 26
+
+
+@pytest.mark.parametrize("pf", pathfinding_modules_to_test)
+def test_path_to_endzone_home_bottom(pf):
+    game = get_game_turn(empty=True)
+    player = game.get_reserves(game.state.home_team)[0]
+    player.role.ma = 6
+    position = Square(4, 15)
+    game.put(player, position)
+    path = pf.get_safest_path_to_endzone(game, player)
+    assert path is not None
+    assert len(path) == 3
+    assert path.steps[-1].x == 1
+
+
+@pytest.mark.parametrize("pf", pathfinding_modules_to_test)
 def test_all_paths(pf):
     game = get_game_turn(empty=True)
     player = game.get_reserves(game.state.away_team)[0]


### PR DESCRIPTION
Adds tests to #226 and a minor fix to the python pathfinder that didn't always pick the shortest path to the endzone.