### PR TITLE
Hotfix to weird multinomial bug

### DIFF
--- a/examples/a2c/a2c_agent.py
+++ b/examples/a2c/a2c_agent.py
@@ -88,6 +88,12 @@ class CNNPolicy(nn.Module):
     def act(self, spatial_inputs, non_spatial_input, action_mask):
         values, action_probs = self.get_action_probs(spatial_inputs, non_spatial_input, action_mask=action_mask)
         actions = action_probs.multinomial(1)
+        # In rare cases, multinomial can  sample an action with p=0, so let's avoid that
+        for i, action in enumerate(actions):
+            correct_action = action
+            while not action_mask[i][correct_action]:
+                correct_action = action_probs[i].multinomial(1)
+            actions[i] = correct_action
         return values, actions
 
     def evaluate_actions(self, spatial_inputs, non_spatial_input, actions, actions_mask):


### PR DESCRIPTION
Fixes #257.

The a2c agent would occasionally sample an action with p=0. It seems that multinomial() will normalize the values if they don't sum to 1. I wonder of some floating point precision errors can cause a 0-probability to become >0.

This is an ugly fix that seems to solve the issue.

```
...
Updates: 6200, Episodes: 8933, Timesteps: 992000, Win rate: 0.99, TD rate: 8.57, TD rate opp: 0.20, Mean reward: 10.010, Difficulty: 1.00
Save log to logs/botbowl-1/091994dd-0061-11ee-8cea-f02f7419d412.dat
Updates: 6250, Episodes: 8999, Timesteps: 1000000, Win rate: 0.99, TD rate: 8.70, TD rate opp: 0.21, Mean reward: 10.386, Difficulty: 1.00
```